### PR TITLE
Fix Python version issue causing MCP package failures

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,10 +10,6 @@
 			"installBicep": true,
 			"version": "latest"
 		},
-		"ghcr.io/devcontainers/features/python:1": {
-			"installTools": true,
-			"version": "os-provided"
-		},
 		"ghcr.io/stuartleeks/dev-container-features/azure-cli-persistence:0": {},
 		"ghcr.io/azure/azure-dev/azd:0": {
 			"version": "stable"
@@ -26,7 +22,7 @@
 		}
 	},
 	"waitFor": "onCreateCommand",
-	"updateContentCommand": "python3 -m pip install --upgrade pip && python3 -m pip install -r requirements.txt",
+	"updateContentCommand": "echo '=== Python Version Debug ===' && python3 --version && which python3 && echo '=== Installing packages ===' && python3 -m pip install --upgrade pip && python3 -m pip install -r requirements.txt",
 	"postCreateCommand": ".devcontainer/post-create.sh",
 	"customizations": {
 	  "codespaces": {


### PR DESCRIPTION
## Problem
MCP package installation was failing with:
```
ERROR: Ignored the following versions that require a different python version: ... Requires-Python >=3.10
ERROR: Could not find a version that satisfies the requirement mcp
```

## Root Cause
The devcontainer had a redundant Python feature:
```json
"ghcr.io/devcontainers/features/python:1": {
    "installTools": true, 
    "version": "os-provided"
}
```

This was conflicting with the base image `python:1-3.11-bullseye` which already provides Python 3.11.

## Solution
- Removed the redundant Python feature
- Added debug output to show actual Python version during builds
- The base image should now provide Python 3.11 natively

## Why the separate file worked before
When we had `requirements-mcp.txt` with error handling (`|| echo 'Warning'`), the main installation succeeded and the MCP failure was silently ignored. Now that we consolidated back to single requirements.txt, the MCP failure blocks the entire installation.

## Testing
This should now show Python 3.11.x in build logs and successfully install MCP packages.

🤖 Generated with [Claude Code](https://claude.ai/code)