### PR TITLE
Upgrade devcontainer to Python 3.13

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "AI Gateway Dev Container",
-	// Using Python bullseye image which has ARM64 support
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
+	// Using Python 3.13 bullseye image which has ARM64 support
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.13-bullseye",
 	"hostRequirements": {
 	  "cpus": 4
 	},


### PR DESCRIPTION
## Summary
Upgrades the devcontainer base image from Python 3.11 to Python 3.13 (latest stable version).

## Changes
- Updated `mcr.microsoft.com/devcontainers/python:1-3.11-bullseye` to `mcr.microsoft.com/devcontainers/python:1-3.13-bullseye`

## Benefits
- **Latest Python features**: Python 3.13 includes performance improvements and new language features
- **Better performance**: Python 3.13 has optimizations that can improve execution speed
- **Security updates**: Latest version includes all security patches
- **ARM64 support maintained**: Bullseye variant continues to provide native ARM64 support for Apple Silicon

## Compatibility
- Python 3.13 is backwards compatible with Python 3.11 code
- All packages in requirements.txt should work with Python 3.13
- MCP packages require Python >=3.10, so 3.13 exceeds this requirement

## Testing
- [ ] Devcontainer builds successfully with Python 3.13
- [ ] All packages in requirements.txt install without errors
- [ ] MCP packages install successfully
- [ ] Post-create script completes without issues

🤖 Generated with [Claude Code](https://claude.ai/code)