### PR TITLE
Fix: OAuth callback/token policies and Weather MCP session validation

### DIFF
--- a/labs/mcp-client-authorization/src/apim-oauth/consent.policy.xml
+++ b/labs/mcp-client-authorization/src/apim-oauth/consent.policy.xml
@@ -242,7 +242,7 @@ __COMMON_STYLES__
                     <set-header name="x-ms-version" exists-action="override">
                         <value>2018-12-31</value>
                     </set-header>
-                    <set-header name="x-ms-partitionkey" exists-action="override">
+                    <set-header name="x-ms-documentdb-partitionkey" exists-action="override">
                         <value>@($"[\"{context.Variables.GetValueOrDefault<string>("client_id")}\"]")</value>
                     </set-header>
                     <set-header name="Authorization" exists-action="override">

--- a/labs/mcp-client-authorization/src/apim-oauth/oauth-callback.policy.xml
+++ b/labs/mcp-client-authorization/src/apim-oauth/oauth-callback.policy.xml
@@ -123,8 +123,8 @@
         <set-variable name="codeChallengeMethod" value="S256" />
         <set-variable name="redirectUri" value="{{OAuthCallbackUri}}" />
         <set-variable name="clientId" value="{{EntraIDClientId}}" />
-        <set-variable name="clientAssertionType" value="@(System.Net.WebUtility.UrlEncode("urn:ietf:params:oauth:client-assertion-type:jwt-bearer"))" />
-        <authentication-managed-identity resource="api://AzureADTokenExchange" client-id="{{EntraIDClientId}}" output-token-variable-name="ficToken"/>
+        <!-- Use confidential client secret for token exchange with Entra ID -->
+        <set-variable name="clientSecret" value="{{EntraIDClientSecret}}" />
          
         <!-- STEP 4: Configure token request to Entra ID -->
         <set-method>POST</set-method>
@@ -132,7 +132,9 @@
             <value>application/x-www-form-urlencoded</value>
         </set-header>
         <set-body>@{
-            return $"client_id={context.Variables.GetValueOrDefault("clientId")}&grant_type=authorization_code&code={context.Variables.GetValueOrDefault("authCode")}&redirect_uri={context.Variables.GetValueOrDefault("redirectUri")}&scope=User.Read&code_verifier={context.Variables.GetValueOrDefault("codeVerifier")}&client_assertion_type={context.Variables.GetValueOrDefault("clientAssertionType")}&client_assertion={context.Variables.GetValueOrDefault("ficToken")}";
+            // Align scope with configured OAuth scopes used during authorize request
+            string scopes = "{{OAuthScopes}}";
+            return $"client_id={context.Variables.GetValueOrDefault("clientId")}&grant_type=authorization_code&code={context.Variables.GetValueOrDefault("authCode")}&redirect_uri={context.Variables.GetValueOrDefault("redirectUri")}&scope={System.Net.WebUtility.UrlEncode(scopes)}&code_verifier={context.Variables.GetValueOrDefault("codeVerifier")}&client_secret={System.Net.WebUtility.UrlEncode((string)context.Variables.GetValueOrDefault("clientSecret"))}";
         }</set-body>
         <rewrite-uri template="/token" />
     </inbound>

--- a/labs/mcp-client-authorization/src/apim-oauth/token.policy.xml
+++ b/labs/mcp-client-authorization/src/apim-oauth/token.policy.xml
@@ -190,7 +190,7 @@
                     <set-header name="x-ms-version" exists-action="override">
                         <value>2018-12-31</value>
                     </set-header>
-                    <set-header name="x-ms-partitionkey" exists-action="override">
+                    <set-header name="x-ms-documentdb-partitionkey" exists-action="override">
                         <value>@($"[\"{context.Variables.GetValueOrDefault<string>("client_id")}\"]")</value>
                     </set-header>
                     <set-header name="Authorization" exists-action="override">

--- a/labs/mcp-client-authorization/src/weather/apim-mcp-server/policy.xml
+++ b/labs/mcp-client-authorization/src/weather/apim-mcp-server/policy.xml
@@ -47,9 +47,10 @@
             byte[] decryptedBytes = inBytes.Decrypt("Aes", key, IV);
             return Encoding.UTF8.GetString(decryptedBytes);
          }" />
-        <!-- if decrypted Session Id does not match the session we should throw error-->
+        <!-- Validate session by checking APIM cache for an Entra token tied to this session ID -->
+        <cache-lookup-value key="@($"EntraToken-{context.Variables.GetValueOrDefault("decryptedSessionId", "")}")" variable-name="sessionEntry" />
         <choose>
-            <when condition="@((string)context.Variables["decryptedSessionId"] != "sessionId123")">
+            <when condition="@(string.IsNullOrEmpty((string)context.Variables.GetValueOrDefault("sessionEntry", "")))">
                 <return-response>
                     <set-status code="401" reason="Unauthorized" />
                     <set-header name="WWW-Authenticate" exists-action="override">
@@ -57,7 +58,7 @@
                     </set-header>
                     <set-body>{
                         "error": "unauthorized",
-                        "error_description": "token is not valid"
+                        "error_description": "session not found or expired"
                         }</set-body>
                 </return-response>
             </when>


### PR DESCRIPTION
Summary
- Fix 500 on /oauth-callback by removing incorrect Managed Identity assertion and using confidential client_secret for token exchange with Entra.
- Align /oauth-callback token request scope with configured OAuthScopes to prevent invalid_scope.
- Fix Cosmos DB partition header used in consent/token flows (x-ms-documentdb-partitionkey) so client lookup works.
- Update Weather MCP API policy to validate decrypted session ID by checking APIM cache entry EntraToken-{sessionId} instead of a hardcoded string.

User impact
- MCP client completes the auth code + PKCE flow and receives an access_token from /token.
- Weather MCP accepts the token in Authorization: Bearer <access_token> and proceeds with the session.

Changes
- labs/mcp-client-authorization/src/apim-oauth/oauth-callback.policy.xml
  - Replace authentication-managed-identity + client_assertion with client_secret.
  - Use scope from {{OAuthScopes}}; keep redirect_uri={{OAuthCallbackUri}} and code_verifier.
- labs/mcp-client-authorization/src/apim-oauth/token.policy.xml
  - Use x-ms-documentdb-partitionkey when reading client registration from Cosmos.
- labs/mcp-client-authorization/src/apim-oauth/consent.policy.xml
  - Use x-ms-documentdb-partitionkey on Cosmos read for client info.
- labs/mcp-client-authorization/src/weather/apim-mcp-server/policy.xml
  - Validate session by cache-lookup EntraToken-{sessionId}; return 401 if not found/expired.

Why
- APIM managed identity call in callback used client-id of the app reg, which selects a user-assigned identity; APIM only had system-assigned MI → policy failure → 500.
- Scope mismatch on callback could cause invalid_scope; now aligned with OAuthScopes used during authorize.
- Cosmos header name was incorrect for the API; reads failed → "client not found" during consent/token.
- Hardcoded session check blocked valid tokens; replaced with cache-backed session verification.

Validation
- Policies pushed to APIM (apim-z5y272qbtsvgi) and verified:
  - /authorize → /oauth-callback → 302 back to MCP client
  - /token → 200 with access_token
  - Weather MCP: Authorization: Bearer <access_token> → accepted

Deployment notes
- No ARM schema changes; policy updates only. Named values required: EntraIDClientId, EntraIDClientSecret, OAuthScopes, OAuthCallbackUri, EncryptionIV, EncryptionKey.

Follow-ups
- Optional: adopt MI token-exchange with a UAI + proper token exchange configuration if desired.
- Optional: adjust OAuthScopes (e.g., add offline_access for refresh tokens).